### PR TITLE
test(integration): reset tmp dir before each test

### DIFF
--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "testRunner": "jest",
-  "coverageAnalysis": "off",
+  "concurrency": 1,
   "reporters": [
     "clear-text",
     "progress",

--- a/tests/multipart-middleware.test.ts
+++ b/tests/multipart-middleware.test.ts
@@ -1,6 +1,7 @@
 import type { Stream } from 'stream';
 import { PassThrough } from 'stream';
-import { createReadStream, readFileSync } from 'fs';
+import { createReadStream, readFileSync, promises as fs } from 'fs';
+import { tmpdir } from 'os';
 import { createHash } from 'crypto';
 import { describe, expect, test } from '@jest/globals';
 import { useFunctionMock } from '@chubbyts/chubbyts-function-mock/dist/function-mock';
@@ -50,6 +51,10 @@ const getStream = async (stream: Stream): Promise<string> => {
     stream.on('error', (error) => reject(error));
   });
 };
+
+beforeEach(async () => {
+  await fs.rm(`${tmpdir()}/multipart`, { force: true, recursive: true });
+});
 
 describe('createMultipartMiddleware', () => {
   test('without content-type', async () => {


### PR DESCRIPTION
This PR fixes https://github.com/stryker-mutator/stryker-js/issues/4739. It does 2 things:

- Set `concurrency: 1` in Stryker config. Since all runs share the same tmpdir, we cannot run tests in parallel
- Reset tmpdir before each test. Since all tests share the same tmpdir, you want to clean it before running a new test.